### PR TITLE
Uses Keystone v2.0 identity API and allows choosing the preferred Swift region

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,10 @@ configurations {
 project.ext {
 	pluginId = "swift"
 	pluginName = "OpenStack Swift"
-	pluginVersion = "0.4.0-alpha"
-	pluginDebianVersion = "1"
+	pluginVersion = "0.4.1-alpha"
+	pluginDebianVersion = "1.1"
 	pluginDate = new Date()
-	pluginAppMinVersion = "0.4.0-alpha"
+	pluginAppMinVersion = "0.4.1-alpha"
 	pluginRelease = rootProject.ext.applicationRelease
 	pluginConflictsWith = ""
 

--- a/src/main/java/org/syncany/plugins/swift/SwiftTransferManager.java
+++ b/src/main/java/org/syncany/plugins/swift/SwiftTransferManager.java
@@ -83,14 +83,29 @@ public class SwiftTransferManager extends AbstractTransferManager {
 	public SwiftTransferManager(SwiftTransferSettings settings, Config config) {
 		super(settings, config);
 
+		boolean usingKeystone = false;
+		
 		AccountConfig authConfig = new AccountConfig();
 		authConfig.setUsername(settings.getUsername());
 		authConfig.setPassword(settings.getPassword());
-		authConfig.setTenantName(settings.getTenantName());
 		authConfig.setAuthUrl(settings.getAuthUrl());
+		
+		if(settings.getTenantName() != null && !settings.getTenantName().equals("")) {
+			authConfig.setTenantName(settings.getTenantName());
+			usingKeystone = true;
+		}
+		
+		if(settings.getTenantId() != null && !settings.getTenantId().equals("")) {
+			authConfig.setTenantId(settings.getTenantId());
+			usingKeystone = true;
+		}
 		
 		if(settings.getPreferredRegion() != null && !settings.getPreferredRegion().equals("")) {
 			authConfig.setPreferredRegion(settings.getPreferredRegion());
+		}
+		
+		if(usingKeystone) {
+			authConfig.setAuthenticationMethod(AuthenticationMethod.KEYSTONE);
 		}
 
 		this.account = new AccountFactory(authConfig).createAccount();

--- a/src/main/java/org/syncany/plugins/swift/SwiftTransferManager.java
+++ b/src/main/java/org/syncany/plugins/swift/SwiftTransferManager.java
@@ -96,11 +96,11 @@ public class SwiftTransferManager extends AbstractTransferManager {
 		this.account = new AccountFactory(authConfig).createAccount();
 
 		this.container = account.getContainer(settings.getContainer());
-		this.multichunksPath = "/multichunks";
-		this.databasesPath = "/databases";
-		this.actionsPath = "/actions";
-		this.transactionsPath = "/transactions";
-		this.tempPath = "/temporary";
+		this.multichunksPath = "multichunks";
+		this.databasesPath = "databases";
+		this.actionsPath = "actions";
+		this.transactionsPath = "transactions";
+		this.tempPath = "temp";
 	}
 
 	@Override

--- a/src/main/java/org/syncany/plugins/swift/SwiftTransferManager.java
+++ b/src/main/java/org/syncany/plugins/swift/SwiftTransferManager.java
@@ -33,6 +33,7 @@ import org.javaswift.joss.model.Account;
 import org.javaswift.joss.model.Container;
 import org.javaswift.joss.model.StoredObject;
 import org.syncany.config.Config;
+import org.syncany.plugins.swift.SwiftTransferSettings;
 import org.syncany.plugins.swift.SwiftTransferManager.SwiftReadAfterWriteConsistentFeatureExtension;
 import org.syncany.plugins.transfer.AbstractTransferManager;
 import org.syncany.plugins.transfer.StorageException;
@@ -85,8 +86,12 @@ public class SwiftTransferManager extends AbstractTransferManager {
 		AccountConfig authConfig = new AccountConfig();
 		authConfig.setUsername(settings.getUsername());
 		authConfig.setPassword(settings.getPassword());
+		authConfig.setTenantName(settings.getTenantName());
 		authConfig.setAuthUrl(settings.getAuthUrl());
-		authConfig.setAuthenticationMethod(AuthenticationMethod.BASIC);
+		
+		if(settings.getPreferredRegion() != null && !settings.getPreferredRegion().equals("")) {
+			authConfig.setPreferredRegion(settings.getPreferredRegion());
+		}
 
 		this.account = new AccountFactory(authConfig).createAccount();
 

--- a/src/main/java/org/syncany/plugins/swift/SwiftTransferSettings.java
+++ b/src/main/java/org/syncany/plugins/swift/SwiftTransferSettings.java
@@ -40,16 +40,20 @@ public class SwiftTransferSettings extends TransferSettings {
 	@Encrypted
 	public String password;
 	
-	@Element(name = "tenantName", required = true)
-	@Setup(order = 4, description = "Tenant name")
+	@Element(name = "tenantName", required = false)
+	@Setup(order = 4, description = "Tenant name (applicable if using Keystone to authenticate)")
 	public String tenantName;
 	
+	@Element(name = "tenantId", required = false)
+	@Setup(order = 5, description = "Tenant ID (applicable if using Keystone to authenticate)")
+	public String tenantId;
+	
 	@Element(name = "container", required = true)
-	@Setup(order = 5, description = "Target container to use")
+	@Setup(order = 6, description = "Target container to use")
 	public String container;
 	
 	@Element(name = "preferredRegion", required = false)
-	@Setup(order = 6, description = "Preferred Swift data region (leave blank to use first applicable region)")
+	@Setup(order = 7, description = "Preferred Swift data region (leave blank to use first applicable region)")
 	public String preferredRegion;
 
 	public String getAuthUrl() {
@@ -66,6 +70,10 @@ public class SwiftTransferSettings extends TransferSettings {
 	
 	public String getTenantName() {
 		return tenantName;
+	}
+	
+	public String getTenantId() {
+		return tenantId;
 	}
 
 	public String getContainer() {

--- a/src/main/java/org/syncany/plugins/swift/SwiftTransferSettings.java
+++ b/src/main/java/org/syncany/plugins/swift/SwiftTransferSettings.java
@@ -39,10 +39,18 @@ public class SwiftTransferSettings extends TransferSettings {
 	@Setup(order = 3, sensitive = true, description = "Password")
 	@Encrypted
 	public String password;
-
+	
+	@Element(name = "tenantName", required = true)
+	@Setup(order = 4, description = "Tenant name")
+	public String tenantName;
+	
 	@Element(name = "container", required = true)
-	@Setup(order = 4, description = "Target container to use")
+	@Setup(order = 5, description = "Target container to use")
 	public String container;
+	
+	@Element(name = "preferredRegion", required = false)
+	@Setup(order = 6, description = "Preferred Swift data region (leave blank to use first applicable region)")
+	public String preferredRegion;
 
 	public String getAuthUrl() {
 		return authUrl;
@@ -55,9 +63,17 @@ public class SwiftTransferSettings extends TransferSettings {
 	public String getPassword() {
 		return password;
 	}
+	
+	public String getTenantName() {
+		return tenantName;
+	}
 
 	public String getContainer() {
 		return container;
+	}
+	
+	public String getPreferredRegion() {
+		return preferredRegion;
 	}
 
 }


### PR DESCRIPTION
This solves [Issue #532](https://github.com/syncany/syncany/issues/532), the previous plugin version only supported Keystone v1.0 Identity API (which is now deprecated). This pull request adds the `tenantName` setting which is required for authentication with v2.0 of the identity API.

This pull request also adds the possibility of choosing the preferred Swift region to choose where to store the data geographically.
